### PR TITLE
introduce devshell

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/fizzy33/a8-scripts/archive/2be5c746c0b77d6df1e47ecbae390a12276dc34e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "devshell": {
+        "branch": "master",
+        "description": "Per project developer environments",
+        "homepage": "https://numtide.github.io/devshell/",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "7033f64dd9ef8d9d8644c5030c73913351d2b660",
+        "sha256": "1vdxzqcjgv1j1z5l0d69gifc1xcd6wk9gcddhza6j4arv9k0axql",
+        "type": "tarball",
+        "url": "https://github.com/numtide/devshell/archive/7033f64dd9ef8d9d8644c5030c73913351d2b660.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "nixpkgs": {
         "branch": "nixos-unstable",
         "description": "Nix Packages collection",

--- a/shell.nix
+++ b/shell.nix
@@ -19,7 +19,11 @@ let
 
   my-sbt = nixpkgs.sbt.override { jre = my-java; };
 in
-devshell.mkShell {
+devshell.mkShell ({ extraModulesPath, ... }: {
+  imports = [
+    "${extraModulesPath}/language/go.nix"
+  ];
+
   # Load packages
   packages = [
     a8-scripts.a8-scripts
@@ -44,4 +48,4 @@ devshell.mkShell {
       category = "nix";
     }
   ];
-}
+})

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,12 @@ let
 
   nixpkgs = import sources.nixpkgs { inherit system; };
 
+  devshell = import sources.devshell {
+    inherit nixpkgs;
+    inputs = null;
+    system = null;
+  };
+
   a8-scripts = import sources.a8-scripts { inherit system nixpkgs; };
 
   my-java = nixpkgs.openjdk11_headless;
@@ -13,8 +19,9 @@ let
 
   my-sbt = nixpkgs.sbt.override { jre = my-java; };
 in
-nixpkgs.mkShell {
-  buildInputs = [
+devshell.mkShell {
+  # Load packages
+  packages = [
     a8-scripts.a8-scripts
     my-ammonite
     my-java
@@ -22,6 +29,19 @@ nixpkgs.mkShell {
     my-scala
     nixpkgs.python3
     nixpkgs.exa
-    nixpkgs.niv
+  ];
+
+  # Set env vars
+  env = [
+    { name = "KEY"; value = "1"; }
+    { name = "SDFSDFG"; eval = "$KEY-xxx"; }
+  ];
+
+  # Add commands in the menu
+  commands = [
+    {
+      package = nixpkgs.niv;
+      category = "nix";
+    }
   ];
 }


### PR DESCRIPTION
Showcase how devshell can replace nixpkgs.mkShell.

 * It's compatible with nix-shell.
 * You can also use the `$(nix-build shell.nix)/entrypoint` script to
   enter the subshell for CI use-cases. It can also take a `--pure`
   argument.
 * It keeps the environment variables pretty lean compared to
   nixpkgs.mkShell.
 * It's extensible using the Nix module system.